### PR TITLE
fix: update meta.js

### DIFF
--- a/src/_data/meta.js
+++ b/src/_data/meta.js
@@ -7,5 +7,5 @@ module.exports = {
   episode:
     'https://www.learnwithjason.dev/subscription-management-in-jamstack-apps',
   tutorial:
-    'https://www.netlify.com/blog/2020/07/13/learn-how-to-add-subscriptions-and-protected-content-with-stripe/?utm_source=demo-footer&utm_medium=stripe-subs-jl&utm_campaign=devex',
+    'https://www.netlify.com/blog/2020/07/13/manage-subscriptions-and-protect-content-with-stripe?utm_source=demo-footer&utm_medium=stripe-subs-jl&utm_campaign=devex',
 };


### PR DESCRIPTION
Current "Tutorial" link in the footer of this app leads to a 404 error. 

**Old Link:** https://www.netlify.com/blog/2020/07/13/learn-how-to-add-subscriptions-and-protected-content-with-stripe/?utm_source=demo-footer&utm_medium=stripe-subs-jl&utm_campaign=devex

**New Link**:  https://www.netlify.com/blog/2020/07/13/manage-subscriptions-and-protect-content-with-stripe?utm_source=demo-footer&utm_medium=stripe-subs-jl&utm_campaign=devex