### PR TITLE
Update deploy link for Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   But don’t worry! You can still: 
   <a href="https://www.learnwithjason.dev/subscription-management-in-jamstack-apps"><strong>watch the video</strong></a> · 
   <a href="https://stripe-subscriptions.netlify.app"><strong>see the demo</strong></a> · 
-  <a href="https://app.netlify.com/start/deploy?repository=https://github.com/stripe-samples/stripe-subscriptions&utm_source=learnwithjason&utm_medium=github&utm_campaign=devex"><strong>deploy this project</strong></a> · 
+  <a href="https://app.netlify.com/start/deploy?repository=https://github.com/stripe-samples/netlify-stripe-subscriptions&utm_source=learnwithjason&utm_medium=github&utm_campaign=devex"><strong>deploy this project</strong></a> · 
   <a href="https://jason.af/lwj/schedule"><strong>see upcoming episodes</strong></a>
 </p>
 


### PR DESCRIPTION
The "deploy this" link for netlify was referring to an old link for this repository. This corrects the broken URL